### PR TITLE
Update sysuthesis.cls

### DIFF
--- a/sysuthesis.cls
+++ b/sysuthesis.cls
@@ -908,7 +908,7 @@
           nameformat = {\zihao{3}\heiti},
           name = {,},
           number = {\arabic{chapter}},
-          aftername = {},
+          % aftername = {},
           titleformat = {\zihao{3}\heiti}
          },
         section = {

--- a/sysuthesis.cls
+++ b/sysuthesis.cls
@@ -143,7 +143,7 @@
 % 表格与图片标题设定
 % https://blog.csdn.net/uncle_gy/article/details/78313861
 % https://tex.stackexchange.com/questions/101591/setting-font-size-for-caption-package
-\renewcommand{\thefigure}{\thechapter-\arabic{figure}}
+\renewcommand{\thefigure}{\thechapter.\arabic{figure}}
 \setlength\heavyrulewidth{0.2em}
 % F19 图题表题 宋体五号
 \DeclareCaptionFormat{sysucaption}{\fontsize{10.5}{10.5}\selectfont#1#2#3}
@@ -828,7 +828,7 @@
     % \paragraph{}
     % \setlength{\baselineskip}{20pt}
     \@cabstract
-    \paragraph{\textbf{【关键词】}}\@ckeywords
+    \paragraph{\textbf{关键词：}}\@ckeywords
 }
 
 % 英文摘要、关键字标题：小四号新罗马体(Time New Roman)加粗并加方括号
@@ -869,7 +869,7 @@
     % F7 英文关键词，小四号，加粗
     \zihao{-4}
     \@eabstract
-    \paragraph{\textbf{[Keywords]}}\@ekeywords
+    \paragraph{\textbf{Keywords:}}\@ekeywords
 }
 
 \newcommand\makeabstract{
@@ -906,7 +906,8 @@
           format = {\centering},
           % F10 正文各章标题 黑体三号居中
           nameformat = {\zihao{3}\heiti},
-          name = {,、},
+          name = {,},
+          number = {\arabic{chapter}},
           aftername = {},
           titleformat = {\zihao{3}\heiti}
          },


### PR DESCRIPTION
1. 图编号(1-1)和表编号(1.1)、公式编号(1.1)样式不同，因此，将图编号改为(1.1)，使样式统一
2. 关键词：摘要正文下方另起一行顶格打印“关键词”款项，后加冒号
3. 论文内文各大部分的标题用“一、二……（或1、2……）”，次级标题为“（一）、（二）……（或1.1、2.1……）”，两类标题不要混编。因此，将“一、二……”改为“1、2……”