### PR TITLE
使用documentclass参数以在main.tex内切换电子/双面打印版

### DIFF
--- a/main.tex
+++ b/main.tex
@@ -1,4 +1,5 @@
-﻿\documentclass{sysuthesis}
+﻿\documentclass{sysuthesis} % 默认使用电子版（不填充空白页）。如果需要双面打印版，请注释掉本行并启用下一行
+% \documentclass[print-both-sides]{sysuthesis} % 使用双面打印版（填充额外空白页以保证每一章开头都在奇数页）
 \usepackage{sysucode}  % 在论文中使用代码
 
 \input{docs/info}     % 论文相关信息

--- a/sysuthesis.cls
+++ b/sysuthesis.cls
@@ -1,6 +1,8 @@
 % 定义模板样式
 \NeedsTeXFormat{LaTeX2e}[1995/12/01]
 \ProvidesClass{sysuthesis}[2017/05/06 v4.5.3 Sun Yat-Sen University undergraduate thesis document class]
+\def\@printtwoside{0} % 默认设置文章为电子版格式（不添加多余空白页）
+\DeclareOption{print-both-sides}{\def\@printtwoside{1}}  % 设置文章为双面打印格式（添加多余空白页保证每个表格、章节开头为奇数页面）
 \DeclareOption*{\PassOptionsToClass{\CurrentOption}{ctexbook}}
 \ProcessOptions\relax
 
@@ -16,8 +18,7 @@
     zihao=-4
 ]{ctexbook}
 
-\def\@printtwoside{0} % 设置文章为电子版格式（不添加多余空白页）
-%\def\@printtwoside{1} % 设置文章为双面打印格式（添加多余空白页保证每个表格、章节开头为奇数页面）
+
 
 % 配置英文字体
 \RequirePackage{fontspec}

--- a/sysuthesis.cls
+++ b/sysuthesis.cls
@@ -1,8 +1,15 @@
 % 定义模板样式
 \NeedsTeXFormat{LaTeX2e}[1995/12/01]
 \ProvidesClass{sysuthesis}[2017/05/06 v4.5.3 Sun Yat-Sen University undergraduate thesis document class]
-\def\@printtwoside{0} % 默认设置文章为电子版格式（不添加多余空白页）
-\DeclareOption{print-both-sides}{\def\@printtwoside{1}}  % 设置文章为双面打印格式（添加多余空白页保证每个表格、章节开头为奇数页面）
+\newcommand{\newclearpage}{\clearpage} % 设置文章为电子版格式（不添加多余空白页）
+\DeclareOption{print-both-sides}{ % 设置文章为双面打印格式（添加多余空白页保证每个表格、章节开头为奇数页面）
+    \renewcommand{\newclearpage}{
+        \clearpage{
+            \pagestyle{empty}
+            \cleardoublepage
+        }
+    }
+}  
 \DeclareOption*{\PassOptionsToClass{\CurrentOption}{ctexbook}}
 \ProcessOptions\relax
 
@@ -57,23 +64,6 @@
 
 % 引入调整段落整体宽度的宏包
 \RequirePackage{changepage}
-
-% Insert a TRUE blank page which has no header or footer
-\let\origdoublepage\cleardoublepage
-\newcommand{\clearemptydoublepage}{
-    \clearpage{
-        \pagestyle{empty}
-        \origdoublepage
-    }
-}
-% 定义了一种新的clearpage方式，允许一个变量切换电子版及双面打印版
-\newcommand{\newclearpage}{
-    \if\@printtwoside1
-        \clearemptydoublepage
-    \else
-        \clearpage
-    \fi
-}
 
 % 设定时间为中文日期
 \ctexset{today=small}


### PR DESCRIPTION
当前的模板切换电子版和双面打印版是需要直接在cls文件里修改一个变量定义。这带来两个问题：一方面大部分学生使用时不会去看cls文件，而其他地方又没提这一点，于是很多学生根本不知道这个（特别有用的）功能的存在；另一方面，用户需要直接改动模板文件来切换一个常用功能，这也不符合类封装的编程范式。

因此本人建议使用documentclass参数来在main.tex开头引入sysuthesis.cls时就可以切换双面打印版和电子版，这样就完成了这个功能的封装，同时main.tex里面的注解学生也更有机会看到。当然，开发者还可以在文档内部增加相关信息告诉学生。