### PR TITLE
Fix CI compile error

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Compile
         run: |
           apt-get update -y
-          apt install --no-install-recommends -y apt-transport-https ca-certificates software-properties-common
+          apt-get install --no-install-recommends -y apt-transport-https ca-certificates software-properties-common
           apt-add-repository non-free
           apt-add-repository contrib
           apt-get update -y

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Compile
         run: |
           apt-get update -y
-          apt-get install --no-install-recommends -y apt-transport-https ca-certificates
+          apt-get install --no-install-recommends -y apt-transport-https lsb-release ca-certificates software-properties-common
           apt-add-repository non-free
           apt-add-repository contrib
           apt-get update -y

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Compile
         run: |
           apt-get update -y
-          apt-get install --no-install-recommends -y apt-transport-https ca-certificates software-properties-common
+          apt-get install --no-install-recommends -y apt-transport-https ca-certificates
           apt-add-repository non-free
           apt-add-repository contrib
           apt-get update -y

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,9 +35,8 @@ jobs:
       - name: Compile
         run: |
           apt-get update -y
-          apt-get install --no-install-recommends -y apt-transport-https lsb-release ca-certificates software-properties-common
-          apt-add-repository non-free
-          apt-add-repository contrib
+          apt install --no-install-recommends -y apt-transport-https ca-certificates software-properties-common
+          sed -i '/^\([^#].*main\)*$/s/main/& contrib non-free/' /etc/apt/sources.list
           apt-get update -y
           apt-get install --no-install-recommends -y ttf-mscorefonts-installer make fonts-arphic-ukai fonts-noto-cjk-extra
           fc-cache


### PR DESCRIPTION
Running `apt-add-repository non-free` and `apt-add-repository contrib` commands inside the `texlive/texlive` container will lead to CI error due to the mis-match between output of `lsb_release -r` and the desired output of Python packet `aptsources` (see details [here](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=513039#27)). This CI fails all other PRs to this project.

This PR offers a workaround by adding `contrib` and `non-free` sources via modifying `/etc/apt/sources.list` file directly with `sed`.