### PR TITLE
修复使用自定义字体文件时标题、章节标题等粗体失效的问题

### DIFF
--- a/ctex-fontset-adobe2.def
+++ b/ctex-fontset-adobe2.def
@@ -17,6 +17,8 @@
 \setCJKfamilyfont { zhsong } { AdobeSongStd-Light.otf       }
   [ 
     Path = ./fonts/,
+    BoldFont   = AdobeHeitiStd-Regular.otf,
+    ItalicFont = AdobeKaitiStd-Regular.otf
   ]
 \setCJKfamilyfont { zhhei  } { AdobeHeitiStd-Regular.otf    }
   [ 


### PR DESCRIPTION
修改了 `ctex-fontset-adobe2.def`文件 `zhsong`的定义，使其可以正常加粗