### PR TITLE
Bug Fixed: 修复更改公式字体后全局英文字体改变

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
     container:
-      image: texlive/texlive:2021
+      image: texlive/texlive:TL2021-historic
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
     container:
-      image: texlive/texlive:latest
+      image: texlive/texlive:2021
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
     container:
-      image: texlive/texlive:TL2021-historic
+      image: texlive/texlive:latest
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/sysuthesis.cls
+++ b/sysuthesis.cls
@@ -30,7 +30,7 @@
 % 配置英文字体
 \RequirePackage{fontspec}
 \setmainfont{Times New Roman}
-\RequirePackage{newtxtext} % 文本自动采用新罗马字体
+%\RequirePackage{newtxtext} % 文本自动采用新罗马字体
 
 % \RequirePackage[margin=1in,headsep=.2in, headheight=2in]{geometry}
 \RequirePackage[top=25mm, bottom=20mm, left=30mm, right=30mm,a4paper]{geometry}

--- a/sysuthesis.cls
+++ b/sysuthesis.cls
@@ -29,7 +29,7 @@
 
 % 配置英文字体
 \RequirePackage{fontspec}
-%\setmainfont{Times New Roman}
+\setmainfont{Times New Roman}
 \RequirePackage{newtxtext} % 文本自动采用新罗马字体
 
 % \RequirePackage[margin=1in,headsep=.2in, headheight=2in]{geometry}
@@ -967,7 +967,7 @@
     % 引用样式
     \bibliographystyle{gbt7714-numerical}
     % F15 参考文献内容 宋体五号
-    {\zihao{5}\rmfamily\songti\bibliography{main}}    % 引用文献列表
+    {\zihao{5}\songti\bibliography{main}}    % 引用文献列表
     \endgroup
 }
 

--- a/sysuthesis.cls
+++ b/sysuthesis.cls
@@ -29,7 +29,8 @@
 
 % 配置英文字体
 \RequirePackage{fontspec}
-\setmainfont{Times New Roman}
+%\setmainfont{Times New Roman}
+\RequirePackage{newtxtext} % 文本自动采用新罗马字体
 
 % \RequirePackage[margin=1in,headsep=.2in, headheight=2in]{geometry}
 \RequirePackage[top=25mm, bottom=20mm, left=30mm, right=30mm,a4paper]{geometry}
@@ -40,6 +41,7 @@
 \RequirePackage[labelsep=space]{caption}
 \RequirePackage[font=footnotesize]{subcaption}
 \RequirePackage{amsmath,amssymb,amsthm}
+\RequirePackage{newtxmath,bm} % 公式使用新罗马字体
 \RequirePackage{ragged2e} % 实现两端对齐
 \RequirePackage{listings}
 \RequirePackage{longtable}

--- a/sysuthesis.cls
+++ b/sysuthesis.cls
@@ -28,9 +28,12 @@
 
 
 % 配置英文字体
-%\RequirePackage{fontspec}
-%\setmainfont{Times New Roman}
-\RequirePackage{newtxtext} % 文本自动采用新罗马字体
+\RequirePackage{fontspec}
+% 如果\RequirePackage{newtxtext}能正常通过编译请注释以下三行，并取消第四行的注释
+\setmainfont{Times New Roman} % 如果注释掉能正常编译，请注释
+\renewcommand*{\rmdefault}{ntxtlf} % always TLF for math
+\renewcommand*{\familydefault}{\rmdefault}
+%\RequirePackage{newtxtext} % 文本自动采用新罗马字体
 
 % \RequirePackage[margin=1in,headsep=.2in, headheight=2in]{geometry}
 \RequirePackage[top=25mm, bottom=20mm, left=30mm, right=30mm,a4paper]{geometry}

--- a/sysuthesis.cls
+++ b/sysuthesis.cls
@@ -29,8 +29,8 @@
 
 % 配置英文字体
 \RequirePackage{fontspec}
-\setmainfont{Times New Roman}
-%\RequirePackage{newtxtext} % 文本自动采用新罗马字体
+%\setmainfont{Times New Roman}
+\RequirePackage{newtxtext} % 文本自动采用新罗马字体
 
 % \RequirePackage[margin=1in,headsep=.2in, headheight=2in]{geometry}
 \RequirePackage[top=25mm, bottom=20mm, left=30mm, right=30mm,a4paper]{geometry}
@@ -967,7 +967,7 @@
     % 引用样式
     \bibliographystyle{gbt7714-numerical}
     % F15 参考文献内容 宋体五号
-    {\zihao{5}\songti\bibliography{main}}    % 引用文献列表
+    {\zihao{5}\rmfamily\songti\bibliography{main}}    % 引用文献列表
     \endgroup
 }
 

--- a/sysuthesis.cls
+++ b/sysuthesis.cls
@@ -970,7 +970,7 @@
     % 引用样式
     \bibliographystyle{gbt7714-numerical}
     % F15 参考文献内容 宋体五号
-    {\zihao{5}\songti\bibliography{main}}    % 引用文献列表
+    {\zihao{5}\rmfamily\songti\bibliography{main}}    % 引用文献列表
     \endgroup
 }
 

--- a/sysuthesis.cls
+++ b/sysuthesis.cls
@@ -30,9 +30,9 @@
 % 配置英文字体
 \RequirePackage{fontspec}
 % 如果\RequirePackage{newtxtext}能正常通过编译请注释以下三行，并取消第四行的注释
-\setmainfont{Times New Roman} % 如果注释掉能正常编译，请注释
 \renewcommand*{\rmdefault}{ntxtlf} % always TLF for math
 \renewcommand*{\familydefault}{\rmdefault}
+\setmainfont{Times New Roman} % 如果注释掉能正常编译，请注释
 %\RequirePackage{newtxtext} % 文本自动采用新罗马字体
 
 % \RequirePackage[margin=1in,headsep=.2in, headheight=2in]{geometry}

--- a/sysuthesis.cls
+++ b/sysuthesis.cls
@@ -28,8 +28,8 @@
 
 
 % 配置英文字体
-\RequirePackage{fontspec}
-\setmainfont{Times New Roman}
+%\RequirePackage{fontspec}
+%\setmainfont{Times New Roman}
 \RequirePackage{newtxtext} % 文本自动采用新罗马字体
 
 % \RequirePackage[margin=1in,headsep=.2in, headheight=2in]{geometry}


### PR DESCRIPTION
之前更改公式字体后，全局英文字体改变，这次更换了一下设置顺序解决了这个问题。
原始代码：
```Tex
 \setmainfont{Times New Roman} 
 \renewcommand*{\rmdefault}{ntxtlf} % always TLF for math
 \renewcommand*{\familydefault}{\rmdefault}
```
修改后代码：
```Tex
 \renewcommand*{\rmdefault}{ntxtlf} % always TLF for math
 \renewcommand*{\familydefault}{\rmdefault}
 \setmainfont{Times New Roman} 
```

原始效果：

![](https://user-images.githubusercontent.com/44627253/212925542-f18446cc-42ce-467d-bb34-33b88890edd0.png)

现在效果：

![](https://user-images.githubusercontent.com/66028151/212912480-b37d1996-e2d6-4228-924e-8452fac3881e.png)
