### PR TITLE
为`Makefile`提供文档

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,13 +10,17 @@ LATEXMK = latexmk -xelatex
 # 	  | egrep -o "v[0-9.]+")
 TEXMF = $(shell kpsewhich --var-value TEXMFHOME)
 
-.PHONY : main cls doc clean all install distclean zip FORCE_MAKE
+.PHONY : main cls doc clean all install distclean zip FORCE_MAKE help
+.DEFAULT_GOAL := help
 
-main : $(MAIN).pdf
+help: ## 显示本 Makefile 常用命令帮助
+	@grep -E '^[a-zA-Z_-]+ :.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = " :.*?## "}; {printf "\033[36m%-15s\033[0m %s\n", $$1, $$2}'
 
-pre : $(PRE).pdf
+main : $(MAIN).pdf ## 编译论文正文 (main.pdf)
 
-all : main pre doc
+pre : $(PRE).pdf ## 编译答辩展示用ppt文档 (pre.pdf)
+
+all : main pre doc ## 编译所有文档 (正文、答辩ppt、说明文档)
 
 cls : $(CLSFILES) $(BSTFILES)
 
@@ -31,10 +35,10 @@ $(PRE).pdf : pre.tex FORCE_MAKE
 $(NAME)-guide.pdf : $(NAME)-guide.tex FORCE_MAKE
 	$(LATEXMK) $<
 
-clean : FORCE_MAKE
+clean : FORCE_MAKE ## 清理编译生成的中间文件
 	$(LATEXMK) -c main.tex pre.tex $(NAME)-guide.tex
 
-cleanall :
+cleanall : ## 清理所有生成的文件（包括 PDF）
 	$(LATEXMK) -C main.tex pre.tex $(NAME)-guide.tex
 
 install : cls doc

--- a/README.md
+++ b/README.md
@@ -40,13 +40,16 @@
 - 对于在线编辑，可以使用 [GitHub Codespaces](https://docs.github.com/zh/codespaces/developing-in-a-codespace/creating-a-codespace-for-a-repository) 通过浏览器版本的 VS Code 进行编辑。（请注意，GitHub Codespaces 每月免费额度有限，请注意用量）。
 - 而对于本地编辑，需要安装 [Docker](https://docs.docker.com/get-docker/) 和 [VS Code](https://code.visualstudio.com/)，并在 VSCode 中安装 [Remote - Containers](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) 插件。随后打开本仓库，键入 `F1`，选择 `Remote-Containers: Reopen in Container` 即可构建进入容器环境。
 
-在容器环境中，可以使用 `make main` 进行编译并生成 `main.pdf` 文件，或者使用 LaTeX Workshop 插件进行编译与预览。
+在容器环境中，可以使用 `make`（或 `make help`）查看所有可用的编译子命令。例如，使用 `make main` 进行编译并生成 `main.pdf` 文件，或者使用 LaTeX Workshop 插件进行编译与预览。
 
 ### texlive 编辑（本地）
 
 本模板需要使用 texlive(>=2020) 进行编译，编译命令如下：
 
-```
+```bash
+# 查看帮助信息，列出所有可用编译子命令
+# make help
+# 编译论文正文
 make main
 ```
 


### PR DESCRIPTION
## 动机

`Makefile`早已集成了调试与写作时常用的命令，但遗憾的是没有文档。目前对于惯于在Linux下写作的同学而言，需要自行阅读文件内容以推测具体命令的用途，因此我稍作了改进，并在项目文档里增添了对应说明。

## 效果

现运行 `make` 或 `make help`会显示命令行帮助：

```
main            编译论文正文 (main.pdf)
pre             编译答辩展示用ppt文档 (pre.pdf)
all             编译所有文档 (正文、答辩ppt、说明文档)
clean           清理编译生成的中间文件
cleanall        清理所有生成的文件（包括 PDF）
```