### PR TITLE
将研究生模板的“1 绪论”改为“第1章 绪论”

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,6 @@
 {
     "latex-workshop.intellisense.unimathsymbols.enabled": true,
+    "latex-workshop.latex.build.enableMagicComments": false,
     "latex-workshop.latex.recipes": [
         {
             "name": "latexmk (xelatex)",
@@ -23,7 +24,9 @@
                 "-interaction=nonstopmode",
                 "-file-line-error",
                 "-xelatex",
+                "-bibtex-cond1",
                 "-outdir=%OUTDIR%",
+                "-auxdir=%AUXDIR%",
                 "%DOC%"
             ],
             "env": {}
@@ -36,10 +39,12 @@
                 "-interaction=nonstopmode",
                 "-file-line-error",
                 "-lualatex",
+                "-bibtex-cond1",
                 "-outdir=%OUTDIR%",
+                "-auxdir=%AUXDIR%",
                 "%DOC%"
             ],
             "env": {}
-        },
+        }
     ]
 }

--- a/sysuthesis.cls
+++ b/sysuthesis.cls
@@ -578,9 +578,12 @@
     \def\listfigurename{插图目录}%
     \def\listtablename{附表目录}%
     \def\sysu@list@figure@table@name{插图和附表目录}%
-    \ctexset{
-      chapter/name   = {},
-    }%
+    \ifsysu@degree@bachelor
+      \ctexset{chapter/name   = {},}%
+    \else
+      \ctexset{chapter/name   = {第,章},}%
+    \fi
+
     \def\bibname{参考文献}%
     \def\appendixname{附录}%
     \def\sysu@acknowledgements@name{致谢}%


### PR DESCRIPTION
将研究生模板的“1 绪论”改为“第1章 绪论”，本科生的保留“1 绪论”
以及本人愿长期维护学校模板，希望加入collaborator，将借鉴中科大模板，第一时间了解可能出现的bug并及时进行修改。